### PR TITLE
Add "R" indicator of missing reference points

### DIFF
--- a/plugin.lua
+++ b/plugin.lua
@@ -358,8 +358,8 @@ local function create_tile_view(folders, folder, index, ts, ti, inRc, outSize)
 
   if showTilesID then
     imi.alignFunc = function(cursor, size, lastBounds)
-      return Point(lastBounds.x,
-                   lastBounds.y+lastBounds.height-size.height)
+      return Point(lastBounds.x+2,
+                   lastBounds.y+lastBounds.height-size.height-2)
     end
     imi.label(string.format("[%d]", ti))
     imi.widget.color = Color(255, 255, 0)
@@ -373,10 +373,21 @@ local function create_tile_view(folders, folder, index, ts, ti, inRc, outSize)
       label = tostring(tilesHistogram[ti])
     end
     imi.alignFunc = function(cursor, size, lastBounds)
-      return lastBounds.origin
+      return Point(lastBounds.x+2,
+                   lastBounds.y+2)
     end
     imi.label(label)
     imi.widget.color = Color(255, 255, 0)
+    imi.alignFunc = nil
+  end
+
+  if ts:tile(ti).properties(PK).referencePoint == nil then
+    imi.alignFunc = function(cursor, size, lastBounds)
+      return Point(lastBounds.x+lastBounds.width-size.width-2,
+                   lastBounds.y+2)
+    end
+    imi.label("R")
+    imi.widget.color = Color(255, 0, 0)
     imi.alignFunc = nil
   end
 


### PR DESCRIPTION
Also added a 2 pixel margin to 'Usage' and 'Tile ID' texts. fix aseprite/Attachment-System#31