### PR TITLE
Fix clipping issue in onpaint method

### DIFF
--- a/imi.lua
+++ b/imi.lua
@@ -341,6 +341,7 @@ function imi.onpaint(ev)
         elseif cmd.type == "restore" then
           ctx:restore()
         elseif cmd.type == "clip" then
+          ctx:beginPath()
           ctx:rect(cmd.bounds)
           ctx:clip()
         end


### PR DESCRIPTION
Fix #33 

The issue was that it was adding rects to the clipping path each time a new clip cmd was sent to the graphics context. Then after the first clip, each subsequent clip had a clip path containing the path of the previous one.