### PR TITLE
Allow attachment deletion from base folder only when unused

### DIFF
--- a/plugin.lua
+++ b/plugin.lua
@@ -780,10 +780,8 @@ local function show_tile_context_menu(ts, ti, folders, folder, indexInFolder)
         end
       end
     end
-    if #frames > 0 then
       app.range.frames = frames
     end
-  end
 
   popup:menuItem{ text="Edit Anchors", onclick=editAnchors }:newrow()
   popup:menuItem{ text="Edit Tile", onclick=editTile }:newrow()


### PR DESCRIPTION
Fix #42 
- Only unused attachments can be deleted from the base folder.
- When an unused tile that was removed from the base folder is used again in the sprite, it is added to the base folder again as the last item.