### PR TITLE
Fix new category not added to properties.categories

### DIFF
--- a/db.lua
+++ b/db.lua
@@ -190,7 +190,12 @@ function db.getLayerProperties(layer)
     layer.tileset.properties(PK).id = id
   end
   if not contains(properties.categories, id) then
-    table.insert(properties.categories, id)
+    local aux = {}
+    for i=1, #properties.categories, 1 do
+      table.insert(aux, properties.categories[i])
+    end
+    table.insert(aux, id)
+    properties.categories = aux
   end
   if not properties.folders or #properties.folders == 0 then
     properties.folders = { createBaseSetFolder(layer) }


### PR DESCRIPTION
'table.insert(properties.categories, id)' do not add the desired 'id'. It was discovered that it cannot added an element via table.insert() when the table argument is the 'properties' of the element (layers, tiles, etc.).