### PR TITLE
Add empty tile creation when new Tilemap layer is created.

### DIFF
--- a/db.lua
+++ b/db.lua
@@ -55,6 +55,9 @@ local function contains(t, item)
 end
 
 local function createBaseSetFolder(layer)
+  if #layer.tileset == 1 then
+    layer.sprite:newTile(layer.tileset, 1)
+  end
   local items = {}
   for ti=1,#layer.tileset-1 do
     table.insert(items, { tile=ti, position=Point(ti-1, 0) })

--- a/plugin.lua
+++ b/plugin.lua
@@ -103,6 +103,9 @@ local function calculate_shrunken_bounds(tilemapLayer)
     local tileImg = ts:getTile(i)
     bounds = bounds:union(tileImg:shrinkBounds())
   end
+  if bounds.width <= 1 and bounds.height <= 1 then
+    return Rectangle(0, 0, 40, 40)
+  end
   return bounds
 end
 


### PR DESCRIPTION
This is done to be able to edit the tile(1), and add new tiles via Attachment System popup menu.