### PR TITLE
Reorder folders and linting issues

### DIFF
--- a/db.lua
+++ b/db.lua
@@ -171,7 +171,7 @@ function db.getBaseSetFolder(layer, folders)
       return folder
     end
   end
-  folder = createBaseSetFolder(layer)
+  local folder = createBaseSetFolder(layer)
   table.insert(folders, folder)
   return folder
 end

--- a/imi.lua
+++ b/imi.lua
@@ -432,7 +432,7 @@ end
 
 -- Call Dialog:repaint() in case that we have to repaint and are
 -- outside ongui() loop.
-function processRepaintFlag()
+local function processRepaintFlag()
   if imi.dlg and
      imi.repaintFlag and
      not imi.isongui then -- If we are ongui() the repaint will be

--- a/imi.lua
+++ b/imi.lua
@@ -789,7 +789,7 @@ function imi._toggle(id, text)
       local widget = updateWidget(id, { bounds=bounds })
       local draggingProcessed = false
 
-      function drawWidget(ctx)
+      local function drawWidget(ctx)
         local bounds = widget.bounds
 
         if widget.dragging and not draggingProcessed then
@@ -1310,6 +1310,16 @@ end
 function imi.getDropData(dataType)
   if imi.dragData then
     return imi.dragData[dataType]
+  else
+    return nil
+  end
+end
+
+function imi.popDropData(dataType)
+  if imi.dragData then
+    local data = imi.dragData[dataType]
+    imi.dragData[dataType] = nil
+    return data
   else
     return nil
   end

--- a/main.lua
+++ b/main.lua
@@ -1303,11 +1303,11 @@ local function show_categories_selector(categories, activeTileset)
   local spr = app.activeSprite
   local categories = activeTilemap.properties(PK).categories
 
-  function rename()
+  local function rename()
     new_or_rename_category_dialog(activeTileset)
   end
 
-  function delete()
+  local function delete()
     app.transaction("Delete Category", function()
       if categories then
         local catID = activeTileset.properties(PK).id
@@ -1511,7 +1511,7 @@ function main.newFolder()
   if folder then
     app.transaction("New Folder", function()
       local layerProperties = db.getLayerProperties(activeTilemap)
-      folders = layerProperties.folders
+      local folders = layerProperties.folders
       table.insert(folders, folder)
       activeTilemap.properties(PK).folders = folders
     end)
@@ -1525,7 +1525,7 @@ local function imi_ongui()
 
   imi.sameLine = true
 
-  function new_layer_button()
+  local function new_layer_button()
     if imi.button("New Layer") then
       app.transaction("New Layer", function()
         -- Create a new tilemap with the grid bounds as the canvas
@@ -1752,7 +1752,7 @@ local function imi_ongui()
                   show_anchor_context_menu(layerId)
                 end
               end
-              imi.popID(layerId)
+              imi.popID()
             end
           end
         end
@@ -2272,7 +2272,7 @@ function main.startSelectingJoint()
     local layer = activeTilemap
     local layerId = layer.properties(PK).id
     local attachments = get_possible_attachments(point)
-    local anchorPoins = nil
+    local anchorPoint = nil
     for i=1,#attachments do
       if attachments[i] ~= layer then
         -- Get base tileset to get anchor points


### PR DESCRIPTION
This PR contains one commit to fix #89 and another commit that fixes some linting issues reported by the VS code Lua linter.

About the folder reordering functionality, this is the most basic implementation, so no fancy visual indicators...just drag a folder button and drop it over another folder button to place it in its position, displacing the following buttons one place.