### PR TITLE
Attachments categories synchronization loss '2' (fix #138)

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -2191,6 +2191,13 @@ local function Sprite_afteraddtile(ev)
   if ev.layer == activeTilemap then
     calculate_shrunken_bounds(activeTilemap)
   end
+
+  for_each_category_tileset(function(ts)
+    if ts ~= layer.tileset then
+      app.sprite:newTile(ts)
+    end
+  end)
+
   imi.repaint()
 end
 


### PR DESCRIPTION
Fixed category desync due to automatic attachment adding in empty cel when the activeTileset is not a base category.

fix #138 

This fix also solves #137